### PR TITLE
Add alternate VSync. Add FM quirk for Tecmo World Cup (#85)

### DIFF
--- a/MegaDrive.sv
+++ b/MegaDrive.sv
@@ -690,7 +690,7 @@ md_board md_board
 	.V_G(g),
 	.V_B(b),
 	.V_HS(hs),
-	.V_VS(vs),
+	.vdp_vsync2(vs),
 	
 	// audio
 	.MOL(MOL),

--- a/rtl/cartridge.sv
+++ b/rtl/cartridge.sv
@@ -850,6 +850,8 @@ always @(posedge clk) begin
 			else if(cart_id[63:0] == "T-25073 ") fmbusy_quirk <= 1;        // Hellfire JP
 			else if(cart_id[63:0] == "MK-1137-") fmbusy_quirk <= 1;        // Hellfire EU
 			else if(cart_id[63:0] == "G-4034  ") fmbusy_quirk <= 1;        // DAISENPU/TWIN HAWK JP/EU
+			else if(cart_id[63:0] == "T-44016 ") fmbusy_quirk <= 1;        // Tecmo World Cup
+			else if(cart_id[63:0] == "T-44023 ") fmbusy_quirk <= 1;        // Tecmo World Cup JP
 			else if(cart_id[63:0] == "T-68???-") schan_quirk  <= 1;        // Game no Kanzume Otokuyou
 			else if(cart_id[63:0] == " GM 0000") sram00_quirk <= 1;        // Sonic 1 Remastered
 			else if(cart_id[87:40] == "SF-001")  sf_quirk     <= {crc == 16'h3E08,2'b01}; // Beggar Prince (Unl), Beggar Prince rev 1 (Unl)

--- a/rtl/nuked-md/fc1004.v
+++ b/rtl/nuked-md/fc1004.v
@@ -205,6 +205,7 @@ module fc1004
 	input [15:0] tmss_data,
 	output [9:0] tmss_address,
 	output vdp_hsync2,
+	output vdp_vsync2,
 	input ym2612_status_enable,
 	output vdp_dma_oe_early,
 	output vdp_dma
@@ -372,6 +373,7 @@ module fc1004
 		.vdp_lcb(vdp_lcb),
 		.vdp_psg_clk1(vdp_psg_clk1),
 		.vdp_hsync2(vdp_hsync2),
+		.vdp_vsync2(vdp_vsync2),
 		.vdp_cramdot_dis(vdp_cramdot_dis),
 		.vdp_dma_oe_early(vdp_dma_oe_early),
 		.vdp_dma(vdp_dma)

--- a/rtl/nuked-md/md_board.v
+++ b/rtl/nuked-md/md_board.v
@@ -125,6 +125,7 @@ module md_board
 	input  vdp_cramdot_dis,
 	output fm_clk1,
 	output vdp_hsync2,
+	output vdp_vsync2,
 	input ym2612_status_enable,
 	input dma_68k_req,
 	input dma_z80_req,
@@ -485,6 +486,7 @@ module md_board
 		.tmss_data(tmss_data),
 		.tmss_address(tmss_address),
 		.vdp_hsync2(vdp_hsync2),
+		.vdp_vsync2(vdp_vsync2),
 		.ym2612_status_enable(ym2612_status_enable),
 		.vdp_dma_oe_early(vdp_dma_oe_early),
 		.vdp_dma(vdp_dma)

--- a/rtl/nuked-md/ym7101.v
+++ b/rtl/nuked-md/ym7101.v
@@ -112,6 +112,7 @@ module ym7101
 	output vdp_lcb,
 	output vdp_psg_clk1,
 	output vdp_hsync2,
+	output vdp_vsync2,
 	input  vdp_cramdot_dis,
 	output vdp_dma_oe_early,
 	output vdp_dma
@@ -4061,6 +4062,8 @@ module ym7101
 	assign VSYNC = w374;
 	assign CSYNC_pull = ~l128;
 	assign HSYNC_pull = ~l136;
+
+	assign vdp_vsync2 = w373;
 
 	// Plane block
 	


### PR DESCRIPTION
Fix blank screens in Psycho Pinball
Fix missing drums in Tecmo World Cup music